### PR TITLE
Clarified that ED is one byte at offset 0x3C

### DIFF
--- a/docs/rom_config_database.md
+++ b/docs/rom_config_database.md
@@ -1,7 +1,7 @@
 # ROM configuration database:
 
 ## Developer override
-The developer ID `ED` will cause the config to be loaded from the ROM header (one byte at offset 0x3F) instead of using the save database built into the ED64 menu.
+The developer ID `0xED` (at ROM offset 0x3C) will cause the config to be loaded from the ROM header (one byte at offset 0x3F) instead of using the save database built into the ED64 menu.
 
 ## Usage
 The ROM ID or CRC HI can be used for game detection (check "ROM Info" from the Everdrive OS menu for the value needed).


### PR DESCRIPTION
Reworded a sentence in the "ROM configuration database" document to be more clear. The original sentence made it seem like ED were two bytes (`'E'` and `'D'`, because the developer ID part of the ROM header is composed of two bytes), and this change clarifies it's one byte, as well as what offset it belongs in.