### PR TITLE
Fixed issues with 0xff padding check and removal

### DIFF
--- a/usb64/usb64/CommandProcessor.cs
+++ b/usb64/usb64/CommandProcessor.cs
@@ -204,18 +204,20 @@ namespace ed64usb
 
                         //Loading a ROM generated with 'makemask' over USB less than 1MB in size doesn't seem to like `0xff` padding. 
                         //Lets remove them as a workaround!
-                        for (int i = romBytes.Count; i > 0; i--) //cycle backwards through the byte array
+                        if (romBytes.Count < 3000000)
                         {
-                            if (romBytes[i] == 0xff)
+                            for (int i = romBytes.Count - 1; i > 0; i--) //cycle backwards through the byte array
                             {
-                                romBytes.RemoveAt(i);
-                            }
-                            else //break on first chance.
-                            {
-                                return;
+                                if (romBytes[i] == 0xff)
+                                {
+                                    romBytes.RemoveAt(i);
+                                }
+                                else //break on first chance.
+                                {
+                                    break;
+                                }
                             }
                         }
-
                         RomWrite(romBytes.ToArray(), baseAddress);
                     }
                 }


### PR DESCRIPTION
## Description
[Fixed issues with 0xff padding check and removal](https://github.com/N64-tools/ED64/commit/3f0f347345aa9356258ff48274567098f1bb32b1)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):